### PR TITLE
Fix/fixed qdata

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,14 +21,16 @@ x-masa-testnet-node-v10-def:
     - -c
     - |
       DDIR=/qdata/dd
-      rm -rf $${DDIR}
+      CONTROL_FILE=$${DDIR}/geth.ipc
       mkdir -p $${DDIR}/keystore
       mkdir -p $${DDIR}/geth
       GENESIS_FILE="/network/genesis.json"
       CONSENSUS_RPC_API="istanbul"
       NETWORK_ID=$$(cat $${GENESIS_FILE} | grep chainId | awk -F " " '{print $$2}' | awk -F "," '{print $$1}')
       GETH_ARGS_istanbul="--emitcheckpoints --istanbul.blockperiod 1 --mine --miner.threads 1 --syncmode full"
-      geth --datadir $${DDIR} init $${GENESIS_FILE}
+      if [ ! -f ${CONTROL_FILE} ]; then
+        geth --datadir $${DDIR} init $${GENESIS_FILE}
+      fi
       geth \
         --identity node$${NODE_ID}-${MASA_CONSENSUS:-istanbul} \
         --datadir $${DDIR} \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,15 +21,15 @@ x-masa-testnet-node-v10-def:
     - -c
     - |
       DDIR=/qdata/dd
-      CONTROL_FILE=$${DDIR}/geth.ipc
-      mkdir -p $${DDIR}/keystore
-      mkdir -p $${DDIR}/geth
       GENESIS_FILE="/network/genesis.json"
       CONSENSUS_RPC_API="istanbul"
       NETWORK_ID=$$(cat $${GENESIS_FILE} | grep chainId | awk -F " " '{print $$2}' | awk -F "," '{print $$1}')
       GETH_ARGS_istanbul="--emitcheckpoints --istanbul.blockperiod 1 --mine --miner.threads 1 --syncmode full"
-      if [ ! -f ${CONTROL_FILE} ]; then
+      if [ ! -f $${DDIR}/control_file ]; then
+        mkdir -p $${DDIR}/keystore
+        mkdir -p $${DDIR}/geth
         geth --datadir $${DDIR} init $${GENESIS_FILE}
+        echo "Created $$(date)" > $${DDIR}/control_file
       fi
       geth \
         --identity node$${NODE_ID}-${MASA_CONSENSUS:-istanbul} \


### PR DESCRIPTION
Creating a control file that will be created when the `geth init` command is run. If this control file already exists, skip the `geth init `command