### PR TITLE
Open 21000 port by default for bootnode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
     hostname: masa-node
     ports:
       - "22001:8545"
+      - "21000:21000"
     volumes:
       - vol1:/qdata
       - ./network/testnet:/network:ro


### PR DESCRIPTION
Hello! For connect to 21000 port i opened his in docker-compose file by default. 