### PR TITLE
Update Docker Compose minimal version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This guide will get you up and running using docker. If you want to us the geth 
 1. Install Docker (https://www.docker.com/get-started)
     - If your Docker distribution does not contain `docker-compose`, follow [this](https://docs.docker.com/compose/install/) to install Docker Compose
     - Make sure your Docker daemon has at least 4G memory
-    - Required: Docker Engine 18.02.0+ and Docker Compose 1.21+
+    - Required: Docker Engine 18.02.0+ and Docker Compose 1.27+
 ## Install The Masa Testnet Node v1.01
 The Docker compose file also launches the Node UI which can be accessed at the following URL
 `http://localhost:3000`


### PR DESCRIPTION
When I tried running the node with docker compose v1.25 I got the following error:
> Unsupported config option for services.ui: 'extends'

I'm no docker expert but after a bit of research it looks like for v3 `extends` is only supported since v1.27. The issue is discussed here
https://github.com/docker/compose/pull/7588